### PR TITLE
FIX: Fix the columnDefinition

### DIFF
--- a/src/main/java/com/risi/risi/entity/PostEntity.java
+++ b/src/main/java/com/risi/risi/entity/PostEntity.java
@@ -2,24 +2,33 @@ package com.risi.risi.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.*;
 
 @Table(name = "post")
 @Entity
-@Data
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class PostEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     private String profile;
     private String username;
+
+    @Column(columnDefinition = "TEXT") // This allows storing long descriptions
     private String title;
+
+    @Column(columnDefinition = "TEXT") // This allows storing long descriptions
     private String description;
+
     private String image;
     private int likes = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     @JsonBackReference
+    @ToString.Exclude
     private UserEntity user;
 }

--- a/src/main/java/com/risi/risi/entity/UserEntity.java
+++ b/src/main/java/com/risi/risi/entity/UserEntity.java
@@ -20,7 +20,10 @@ public class UserEntity {
     private String userId;
     private String username;
     private String password;
+
+    @Column(columnDefinition = "TEXT") // This allows storing long descriptions
     private String description = "";
+
     private String image = "";
     private String role;
     private String token;


### PR DESCRIPTION
# Fixed
* Fixed the columnDefinition of description from UserEntity and PostEntity
* Fixed the columnDefinition of title from PostEntity.
* By putting following code.
  ```java
  @Column(columnDefinition = "TEXT") // This allows storing long descriptions
  ```
<br>